### PR TITLE
Fix selection of passenger vehicles

### DIFF
--- a/airnetwork.nut
+++ b/airnetwork.nut
@@ -100,7 +100,7 @@ function AirNetwork::ManageAir()
 			}
 
 			// Build it and order it to go from A -> B
-			local acraft_id = AIVehicle.BuildVehicle(hangar, engine);
+			local acraft_id = AIVehicle.BuildVehicleWithRefit(hangar, engine, this.passenger_cargo_id);
 
 			if(AIVehicle.IsValidVehicle(acraft_id))
 			{
@@ -159,7 +159,7 @@ function AirNetwork::ManageAir()
 			}
 
 			// Build it
-			local clone_id = AIVehicle.BuildVehicle(hangar, engine);
+			local clone_id = AIVehicle.BuildVehicleWithRefit(hangar, engine, this.passenger_cargo_id);
 			if(AIVehicle.IsValidVehicle(clone_id))
 			{
 				AIOrder.AppendOrder(clone_id, AIStation.GetLocation(i), AIOrder.OF_NONE);
@@ -264,8 +264,8 @@ function AirNetwork::SelectNewEngine()
 {
 	local engine_list = AIEngineList(AIVehicle.VT_AIR);
 
-	engine_list.Valuate(AIEngine.GetCargoType);
-	engine_list.KeepValue(this.passenger_cargo_id);
+	engine_list.Valuate(AIEngine.CanRefitCargo, this.passenger_cargo_id);
+	engine_list.KeepValue(1);
 
 	engine_list.Valuate(AIEngine.GetCapacity);
 	engine_list.Sort(AIList.SORT_BY_VALUE, AIList.SORT_DESCENDING);

--- a/roadnetwork.nut
+++ b/roadnetwork.nut
@@ -571,7 +571,7 @@ function RoadNetwork::FillRoute(towna,townb,stationa,stationb,depot)
 	}
 
 	// Buy it
-	local vehicle_id = AIVehicle.BuildVehicle(depot, engine);
+	local vehicle_id = AIVehicle.BuildVehicleWithRefit(depot, engine, this.passenger_cargo_id);
 
 	// Add orders
 	AIOrder.AppendOrder(vehicle_id, stationa,0);
@@ -610,8 +610,8 @@ function RoadNetwork::SelectNewEngine()
 	engine_list.Valuate(AIEngine.GetRoadType);
 	engine_list.KeepValue(AIRoad.ROADTYPE_ROAD);
 
-	engine_list.Valuate(AIEngine.GetCargoType);
-	engine_list.KeepValue(passenger_cargo_id);
+	engine_list.Valuate(AIEngine.CanRefitCargo, this.passenger_cargo_id);
+	engine_list.KeepValue(1);
 
 	engine_list.Valuate(AIEngine.GetReliability);
 	engine_list.KeepTop(1); // We want the best Reliability


### PR DESCRIPTION
Fix selection of passenger vehicles:

* Choose vehicles which can be refitted to passengers instead of vehicles which default to passengers.
* Use BuildVehicleWithRefit in case default cargo is not passengers.

This allows correct operation when passengers are not a vehicle's default cargo type, which is common with e.g. FIRS 5.

Sorting by capacity will sort by the capacity of the default cargo, so may not be exactly as intended.